### PR TITLE
Techradar update december 2022

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,9 +4,9 @@ Please include a summary of the change and which issue is fixed. Please also inc
 List any dependencies that are required for this change. 
 
 ### What did change on the Tech Radar?
-|Name|Quadrant|Ring|Move|
-|---|---|---|---|
-|Jaeger|Infrastructure	|Trial|1|
+|Name|Quadrant| Ring         |
+|---|---|--------------|
+|Jaeger|Infrastructure	| Trial -> Use |
 
 ### Checklist:
 - [ ] Someone from the [Techradar members](https://productsup.atlassian.net/wiki/spaces/EN/pages/1815380194/Tech+Radar#Who-is-part-of-the-Tech-Radar-board?) has approved/reviewed changes

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ Feel free to use and adapt it for your own purposes.
 1. Adjust or add technologies in our [Google Sheet](https://docs.google.com/spreadsheets/d/1Op2gILhJWK1YldR60xWBYMKxajSkHsy25DL_7y14HpU/edit?id=1Op2gILhJWK1YldR60xWBYMKxajSkHsy25DL_7y14HpU#gid=0) <br/>
 **FYI:** Only the [Techradar board members](https://productsup.atlassian.net/wiki/spaces/EN/pages/1815380194/Tech+Radar#Who-is-part-of-the-Tech-Radar-board?) have write access to this sheet.
 2. Create a new branch and a PR
-3. Generate a new version by executing `docker-compose run --rm cli yarn generate` on the root of this project
-4. Commit the changed files
-5. Follow the review process in the PR template
-6. Merge the PR
-7. Create a new release in GitHub
+3. Install dependencies with yarn (or npm) `docker-compose run --rm cli yarn`
+4. Generate a new version by executing `docker-compose run --rm cli yarn generate` on the root of this project
+5. Commit the changed files
+6. Follow the review process in the PR template
+7. Merge the PR
+8. Create a new release in GitHub
 
 **That's it!!**
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,11 +81,11 @@ radar_visualization(/* RADAR START */{
             "ring": 0
         }, 
         {
-            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2829418601/Antora\">Antora</a> in our Documentation.", 
             "label": "Antora", 
-            "moved": "0", 
+            "moved": "1", 
             "quadrant": 1, 
-            "ring": 1
+            "ring": 0
         }, 
         {
             "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2587721729/Apache+Spark\">Apache Spark</a> in our Documentation.", 
@@ -134,7 +134,7 @@ radar_visualization(/* RADAR START */{
             "label": "Behat", 
             "moved": "0", 
             "quadrant": 2, 
-            "ring": 1
+            "ring": 0
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -165,6 +165,13 @@ radar_visualization(/* RADAR START */{
             "ring": 0
         }, 
         {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2829287605/Distrib\">Distrib</a> in our Documentation.", 
+            "label": "Distrib", 
+            "moved": "1", 
+            "quadrant": 1, 
+            "ring": 0
+        }, 
+        {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Docker", 
             "moved": "0", 
@@ -186,11 +193,11 @@ radar_visualization(/* RADAR START */{
             "ring": 0
         }, 
         {
-            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2829451355/Elastic+Search\">Elastic Search</a> in our Documentation.", 
             "label": "Elastic Search", 
-            "moved": "0", 
+            "moved": "-1", 
             "quadrant": 3, 
-            "ring": 0
+            "ring": 3
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -291,18 +298,18 @@ radar_visualization(/* RADAR START */{
             "ring": 3
         }, 
         {
-            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://github.com/productsupcom/php-jsonchunk\">JSON PHP extension</a> in our Documentation.", 
-            "label": "JSON PHP extension", 
-            "moved": "1", 
-            "quadrant": 2, 
-            "ring": 2
-        }, 
-        {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "jQuery", 
             "moved": "0", 
             "quadrant": 2, 
             "ring": 3
+        }, 
+        {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://github.com/productsupcom/php-jsonchunk\">JSON PHP extension</a> in our Documentation.", 
+            "label": "JSON PHP extension", 
+            "moved": "0", 
+            "quadrant": 2, 
+            "ring": 2
         }, 
         {
             "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2367586858/Apache+Kafka\">Kafka</a> in our Documentation.", 
@@ -314,7 +321,7 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Keras", 
-            "moved": "1", 
+            "moved": "0", 
             "quadrant": 2, 
             "ring": 2
         }, 
@@ -336,6 +343,13 @@ radar_visualization(/* RADAR START */{
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Laravel components", 
             "moved": "0", 
+            "quadrant": 2, 
+            "ring": 0
+        }, 
+        {
+            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "label": "Laravel Framework 9 ", 
+            "moved": "1", 
             "quadrant": 2, 
             "ring": 0
         }, 
@@ -417,11 +431,25 @@ radar_visualization(/* RADAR START */{
             "ring": 0
         }, 
         {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2829516908/OpenSearch\">OpenSearch</a> in our Documentation.", 
+            "label": "OpenSearch", 
+            "moved": "1", 
+            "quadrant": 1, 
+            "ring": 1
+        }, 
+        {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "OpenVPN", 
             "moved": "0", 
             "quadrant": 1, 
             "ring": 0
+        }, 
+        {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://grafana.com/oss/phlare/\">Phlare</a> in our Documentation.", 
+            "label": "Phlare", 
+            "moved": "1", 
+            "quadrant": 1, 
+            "ring": 2
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -433,14 +461,21 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "PHP 8.0", 
-            "moved": "0", 
+            "moved": "-1", 
+            "quadrant": 0, 
+            "ring": 3
+        }, 
+        {
+            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "label": "PHP 8.1", 
+            "moved": "1", 
             "quadrant": 0, 
             "ring": 0
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
-            "label": "PHP 8.1", 
-            "moved": "0", 
+            "label": "PHP 8.2", 
+            "moved": "1", 
             "quadrant": 0, 
             "ring": 1
         }, 
@@ -467,6 +502,13 @@ radar_visualization(/* RADAR START */{
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "label": "PostgreSQL 14", 
+            "moved": "1", 
+            "quadrant": 3, 
+            "ring": 0
+        }, 
+        {
+            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Prometheus", 
             "moved": "0", 
             "quadrant": 1, 
@@ -482,14 +524,14 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Python 2", 
-            "moved": "-1", 
+            "moved": "0", 
             "quadrant": 0, 
             "ring": 3
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Python 3", 
-            "moved": "1", 
+            "moved": "0", 
             "quadrant": 0, 
             "ring": 0
         }, 
@@ -578,11 +620,11 @@ radar_visualization(/* RADAR START */{
             "ring": 0
         }, 
         {
-            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2013003815/Supervisord\">Supervisord</a> in our Documentation.", 
             "label": "Supervisord", 
-            "moved": "0", 
+            "moved": "1", 
             "quadrant": 1, 
-            "ring": 1
+            "ring": 0
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -607,6 +649,13 @@ radar_visualization(/* RADAR START */{
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "label": "Symfony 6.1", 
+            "moved": "1", 
+            "quadrant": 2, 
+            "ring": 1
+        }, 
+        {
+            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Symfony Components", 
             "moved": "0", 
             "quadrant": 2, 
@@ -615,7 +664,7 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Tensorflow", 
-            "moved": "1", 
+            "moved": "0", 
             "quadrant": 2, 
             "ring": 2
         }, 
@@ -669,7 +718,7 @@ radar_visualization(/* RADAR START */{
         }
     ], 
     "svg_id": "radar", 
-    "title": "Productsup Tech Radar \u2014 as of 2022.10", 
+    "title": "Productsup Tech Radar \u2014 as of 2022.12", 
     "width": 1450
 }/* RADAR END */);
 </script>

--- a/docs/radar.js
+++ b/docs/radar.js
@@ -280,7 +280,7 @@ function radar_visualization(config) {
 
     // footer
     radar.append("text")
-      .attr("transform", translate(footer_offset.x, (footer_offset.y+40)))
+      .attr("transform", translate(footer_offset.x, (footer_offset.y+60)))
       .text("▲ moved up     ▼ moved down")
       .attr("xml:space", "preserve")
       .style("font-family", "Arial, Helvetica")


### PR DESCRIPTION
## Description

https://productsup.atlassian.net/wiki/spaces/EN/pages/2822439039/2022-12-22+-+Tech+Radar?focusedTaskId=1
https://productsup.atlassian.net/wiki/spaces/EN/pages/2828697635/Techradar+Update+-+December+2022

### What did change on the Tech Radar?
|Name|Quadrant|Ring|
|---|---|---|
|Antora | Infrastructure | Trial -> Use |
|Distrib | Infrastructure | Use |
|Elastic Search | Data Management | Use -> Hold |
|Laravel Framework 9 | Frameworks | Use |
|OpenSearch | Infrastructure | Trial |
|Phlare | Infrastructure | Assess |
|PHP 8.0 | Languages | Use -> Hold | 
|PHP 8.1 | Languages | Trial -> Use |
|PHP 8.2 | Languages | Trial |
|PostgreSQL 14 | Data Management | Use |
|Supervisord | Infrastructure | Trial -> Use |
|Symfony 6.1 | Frameworks | Trial |



### Checklist:
- [ ] Someone from the [Techradar members](https://productsup.atlassian.net/wiki/spaces/EN/pages/1815380194/Tech+Radar#Who-is-part-of-the-Tech-Radar-board?) has approved/reviewed changes
- [ ] The Techradar website is still working locally (```yarn start```)