### PR TITLE
Created a new version of the tech radar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,24 +47,17 @@ radar_visualization(/* RADAR START */{
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
-            "label": "Angular 11", 
-            "moved": "0", 
+            "label": "Angular 13", 
+            "moved": "-1", 
             "quadrant": 2, 
             "ring": 3
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
-            "label": "Angular 13", 
-            "moved": "0", 
+            "label": "Angular 16", 
+            "moved": "1", 
             "quadrant": 2, 
             "ring": 0
-        }, 
-        {
-            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
-            "label": "Angular 7", 
-            "moved": "0", 
-            "quadrant": 2, 
-            "ring": 3
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -83,16 +76,16 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2829418601/Antora\">Antora</a> in our Documentation.", 
             "label": "Antora", 
-            "moved": "1", 
+            "moved": "0", 
             "quadrant": 1, 
             "ring": 0
         }, 
         {
             "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2587721729/Apache+Spark\">Apache Spark</a> in our Documentation.", 
             "label": "Apache Spark", 
-            "moved": "0", 
+            "moved": "-1", 
             "quadrant": 2, 
-            "ring": 2
+            "ring": 3
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -102,11 +95,18 @@ radar_visualization(/* RADAR START */{
             "ring": 1
         }, 
         {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2956165242/AWS+Cognito\">AWS Cognito</a> in our Documentation.", 
+            "label": "AWS Cognito", 
+            "moved": "1", 
+            "quadrant": 1, 
+            "ring": 0
+        }, 
+        {
             "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2597486593/AWS+EC2\">AWS EC2</a> in our Documentation.", 
             "label": "AWS EC2", 
-            "moved": "0", 
+            "moved": "-1", 
             "quadrant": 1, 
-            "ring": 2
+            "ring": 3
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -151,6 +151,13 @@ radar_visualization(/* RADAR START */{
             "ring": 0
         }, 
         {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2956329218/Clair\">Clair</a> in our Documentation.", 
+            "label": "Clair", 
+            "moved": "1", 
+            "quadrant": 1, 
+            "ring": 1
+        }, 
+        {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Clickhouse", 
             "moved": "0", 
@@ -167,9 +174,9 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2829287605/Distrib\">Distrib</a> in our Documentation.", 
             "label": "Distrib", 
-            "moved": "1", 
+            "moved": "-1", 
             "quadrant": 1, 
-            "ring": 0
+            "ring": 3
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -195,7 +202,7 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2829451355/Elastic+Search\">Elastic Search</a> in our Documentation.", 
             "label": "Elastic Search", 
-            "moved": "-1", 
+            "moved": "0", 
             "quadrant": 3, 
             "ring": 3
         }, 
@@ -231,6 +238,13 @@ radar_visualization(/* RADAR START */{
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Graylog", 
             "moved": "0", 
+            "quadrant": 1, 
+            "ring": 0
+        }, 
+        {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2955477280/Growthbook\">Growthbook</a> in our Documentation.", 
+            "label": "Growthbook", 
+            "moved": "1", 
             "quadrant": 1, 
             "ring": 0
         }, 
@@ -326,11 +340,11 @@ radar_visualization(/* RADAR START */{
             "ring": 2
         }, 
         {
-            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/3059613822/Keycloak+in+progress\">Keycloak</a> in our Documentation.", 
             "label": "Keycloak", 
-            "moved": "0", 
+            "moved": "1", 
             "quadrant": 1, 
-            "ring": 2
+            "ring": 1
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -341,15 +355,22 @@ radar_visualization(/* RADAR START */{
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "label": "Laravel 10", 
+            "moved": "1", 
+            "quadrant": 2, 
+            "ring": 2
+        }, 
+        {
+            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Laravel components", 
             "moved": "0", 
             "quadrant": 2, 
             "ring": 0
         }, 
         {
-            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2956001527/Laravel\">Laravel Framework 9 </a> in our Documentation.", 
             "label": "Laravel Framework 9 ", 
-            "moved": "1", 
+            "moved": "0", 
             "quadrant": 2, 
             "ring": 0
         }, 
@@ -368,6 +389,13 @@ radar_visualization(/* RADAR START */{
             "ring": 0
         }, 
         {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2947416155/Grafana+Mimir\">Mimir</a> in our Documentation.", 
+            "label": "Mimir", 
+            "moved": "1", 
+            "quadrant": 1, 
+            "ring": 0
+        }, 
+        {
             "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2594832385/Mongo+DB\">MongoDB</a> in our Documentation.", 
             "label": "MongoDB", 
             "moved": "0", 
@@ -379,6 +407,13 @@ radar_visualization(/* RADAR START */{
             "label": "Mysql (MariaDB)", 
             "moved": "0", 
             "quadrant": 3, 
+            "ring": 0
+        }, 
+        {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2947350634/NetBox\">NetBox</a> in our Documentation.", 
+            "label": "NetBox", 
+            "moved": "1", 
+            "quadrant": 1, 
             "ring": 0
         }, 
         {
@@ -401,6 +436,13 @@ radar_visualization(/* RADAR START */{
             "moved": "0", 
             "quadrant": 2, 
             "ring": 2
+        }, 
+        {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2946924709/Hashicorp+Nomad\">Nomad</a> in our Documentation.", 
+            "label": "Nomad", 
+            "moved": "1", 
+            "quadrant": 1, 
+            "ring": 1
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -433,7 +475,7 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2829516908/OpenSearch\">OpenSearch</a> in our Documentation.", 
             "label": "OpenSearch", 
-            "moved": "1", 
+            "moved": "0", 
             "quadrant": 1, 
             "ring": 1
         }, 
@@ -445,11 +487,11 @@ radar_visualization(/* RADAR START */{
             "ring": 0
         }, 
         {
-            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://grafana.com/oss/phlare/\">Phlare</a> in our Documentation.", 
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2947350614/Grafana+Phlare\">Phlare</a> in our Documentation.", 
             "label": "Phlare", 
-            "moved": "1", 
+            "moved": "-1", 
             "quadrant": 1, 
-            "ring": 2
+            "ring": 3
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -461,21 +503,21 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "PHP 8.0", 
-            "moved": "-1", 
+            "moved": "0", 
             "quadrant": 0, 
             "ring": 3
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "PHP 8.1", 
-            "moved": "1", 
+            "moved": "0", 
             "quadrant": 0, 
             "ring": 0
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "PHP 8.2", 
-            "moved": "1", 
+            "moved": "0", 
             "quadrant": 0, 
             "ring": 1
         }, 
@@ -501,9 +543,16 @@ radar_visualization(/* RADAR START */{
             "ring": 0
         }, 
         {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://playwright.dev/\">Playwright</a> in our Documentation.", 
+            "label": "Playwright", 
+            "moved": "1", 
+            "quadrant": 2, 
+            "ring": 0
+        }, 
+        {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "PostgreSQL 14", 
-            "moved": "1", 
+            "moved": "0", 
             "quadrant": 3, 
             "ring": 0
         }, 
@@ -536,6 +585,13 @@ radar_visualization(/* RADAR START */{
             "ring": 0
         }, 
         {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2955804964/Quay\">Quay</a> in our Documentation.", 
+            "label": "Quay", 
+            "moved": "1", 
+            "quadrant": 1, 
+            "ring": 0
+        }, 
+        {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "React", 
             "moved": "0", 
@@ -564,6 +620,13 @@ radar_visualization(/* RADAR START */{
             "ring": 1
         }, 
         {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://roadrunner.dev/\">RoadRunner</a> in our Documentation.", 
+            "label": "RoadRunner", 
+            "moved": "1", 
+            "quadrant": 2, 
+            "ring": 2
+        }, 
+        {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Rundeck", 
             "moved": "0", 
@@ -587,9 +650,9 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2592669705/Selenium\">Selenium</a> in our Documentation.", 
             "label": "Selenium", 
-            "moved": "0", 
+            "moved": "-1", 
             "quadrant": 2, 
-            "ring": 1
+            "ring": 3
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -622,9 +685,16 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/2013003815/Supervisord\">Supervisord</a> in our Documentation.", 
             "label": "Supervisord", 
-            "moved": "1", 
+            "moved": "0", 
             "quadrant": 1, 
             "ring": 0
+        }, 
+        {
+            "explanation": "Learn more about: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://www.php.net/manual/en/intro.swoole.php\">Swoole</a> in our Documentation.", 
+            "label": "Swoole", 
+            "moved": "1", 
+            "quadrant": 2, 
+            "ring": 2
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -636,23 +706,16 @@ radar_visualization(/* RADAR START */{
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
             "label": "Symfony 5", 
-            "moved": "0", 
+            "moved": "-1", 
             "quadrant": 2, 
             "ring": 3
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
-            "label": "Symfony 5.2", 
-            "moved": "0", 
-            "quadrant": 2, 
-            "ring": 0
-        }, 
-        {
-            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
-            "label": "Symfony 6.1", 
+            "label": "Symfony 6", 
             "moved": "1", 
             "quadrant": 2, 
-            "ring": 1
+            "ring": 0
         }, 
         {
             "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
@@ -673,6 +736,20 @@ radar_visualization(/* RADAR START */{
             "label": "Typescript", 
             "moved": "0", 
             "quadrant": 0, 
+            "ring": 0
+        }, 
+        {
+            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "label": "Vue.js 3", 
+            "moved": "1", 
+            "quadrant": 2, 
+            "ring": 0
+        }, 
+        {
+            "explanation": "No Confluence page available. please check out: <a target=\"_blank\" style=\"font-size:12pt\" href=\"https://productsup.atlassian.net/wiki/spaces/EN/pages/1930429957/Overview+Technologies\">Tech Radar Technologies</a>", 
+            "label": "VyOS", 
+            "moved": "1", 
+            "quadrant": 1, 
             "ring": 0
         }, 
         {
@@ -718,7 +795,7 @@ radar_visualization(/* RADAR START */{
         }
     ], 
     "svg_id": "radar", 
-    "title": "Productsup Tech Radar \u2014 as of 2022.12", 
+    "title": "Productsup Tech Radar \u2014 as of 2023.07", 
     "width": 1450
 }/* RADAR END */);
 </script>
@@ -736,7 +813,7 @@ The Productsup Tech Radar is a list of technologies, complemented by an assessme
 <ul>
 <li><strong>USE</strong> &mdash; Technologies we have high confidence in to serve our purpose, also in large scale. Technologies with a usage culture in our Productsup production environment, low risk and recommended to be widely used.</li>
 <li><strong>TRIAL</strong> &mdash; Technologies that we have seen work with success in project work to solve a real problem; first serious usage experience that confirm benefits and can uncover limitations. TRIAL technologies are slightly more risky; some engineers in our organization walked this path and will share knowledge and experiences.</li>
-<li><strong>STRATEGIC</strong> &mdash; Technologies that are promising and have clear potential value-add for us; technologies worth to invest some research and prototyping efforts in to see if it has impact. STRATEGIC technologies have higher risks; they are often brand new and highly unproven in our organisation. You will find some engineers that have knowledge in the technology and promote it, you may even find teams that have started a prototyping effort.</li>
+<li><strong>ASSESS</strong> &mdash; Technologies that are promising and have clear potential value-add for us; technologies worth to invest some research and prototyping efforts in to see if it has impact. ASSESS technologies have higher risks; they are often brand new and highly unproven in our organisation. You will find some engineers that have knowledge in the technology and promote it, you may even find teams that have started a prototyping effort.</li>
 <li><strong>HOLD</strong> &mdash; Technologies not recommended to be used for new projects. Technologies that we think are not (yet) worth to (further) invest in. HOLD technologies should not be used for new projects, but usually can be continued for existing projects.</li>
 </ul>
 


### PR DESCRIPTION
## Description

https://productsup.atlassian.net/wiki/spaces/EN/pages/3054567507/2023-06-29+-+Tech+Radar

### What did change on the Tech Radar?
|Name| Ring         |
|---|--------------|
Angular 13 | USE -> Hold
Angular 16 | n/a  -> USE
Apache Spark | Assess -> Hold
AWS Cognito | n/a -> USE
AWS EC2 | Assess -> Hold
Clair | n/a -> Trial
Distrib | USE -> Hold
Growthbook | n/a -> USE
Keycloak | Assess -> Trial
Laravel 10 | n/a -> Assess
Grafana Mimir | n/a -> USE
NetBox | n/a -> USE
Hashicorp Nomad | n/a -> Trial
Grafana Phlare | Assess -> Hold
Playwright | n/a -> USE
Quay | n/a -> USE
RoadRunner | n/a  -> Assess
Selenium | Trial -> Hold
Swoole | n/a -> Assess
Symfony 6 | Trial -> USE
Symfony 5 | USE -> Hold
Vue.js 3 | n/a -> USE
VyOS | n/a -> USE


### Checklist:
- [ ] Someone from the [Techradar members](https://productsup.atlassian.net/wiki/spaces/EN/pages/1815380194/Tech+Radar#Who-is-part-of-the-Tech-Radar-board?) has approved/reviewed changes
- [ ] The Techradar website is still working locally (```yarn start```)